### PR TITLE
Announce planned ERDA maintenance from 1st of Dec 2025

### DIFF
--- a/state/wwwpublic/status-events.json
+++ b/state/wwwpublic/status-events.json
@@ -1,5 +1,4 @@
 [
-
   {
     "status": "AUTO",
     "work_start": "2025-01-01T18:00:00+01:00",
@@ -17,7 +16,7 @@
     "work_end": "2025-01-02T10:00:00+01:00",
     "description": {
         "EN": "General system upgrades, and final transitioning to new authentication service OpenID Connect.",
-        "DK": "Generelle systemopdateringer, samt endelig overgang til ny autentikeringstjeneste OpenID Connect."
+        "DK": "Generelle systemopdateringer, samt endelig overgang til ny autentificeringstjeneste, OpenID Connect."
     },
     "announce_end": "2025-01-03T12:00:00+01:00"
   },

--- a/state/wwwpublic/status-events.json
+++ b/state/wwwpublic/status-events.json
@@ -1,4 +1,26 @@
 [
+
+  {
+    "status": "AUTO",
+    "work_start": "2025-01-01T18:00:00+01:00",
+    "systems": [
+        "ERDA"
+    ],
+    "announce_start": "2024-12-20T08:00:00+01:00",
+    "title": {
+      "EN": "Planned systems maintenance on ERDA",
+      "DK": "Planlagt systemvedligehold på ERDA"
+    },
+    "services": [
+        "ALL"
+    ],
+    "work_end": "2025-01-02T10:00:00+01:00",
+    "description": {
+        "EN": "General system upgrades, and final transitioning to new authentication service OpenID Connect.",
+        "DK": "Generelle systemopdateringer, samt endelig overgang til ny autentikeringstjeneste OpenID Connect."
+    },
+    "announce_end": "2025-01-03T12:00:00+01:00"
+  },
   {
     "status": "AUTO",
     "work_start": "2024-12-05T21:00:00+01:00",


### PR DESCRIPTION
Not sure about time zones and end of announcement.
Supposed to be from 1st (18:00) to 2nd (10:00) of January 2025 (CPH timezone).
Also not sure on annouce_end, it is set to 26h after work_end.