### PR TITLE
Fix a number of status event entries incorrectly declared as ALL systems

### DIFF
--- a/state/wwwpublic/status-events.json
+++ b/state/wwwpublic/status-events.json
@@ -160,7 +160,7 @@
     "status": "AUTO",
     "work_start": "2025-03-15T11:00:00+01:00",
     "systems": [
-        "ALL"
+        "ERDA"
     ],
     "announce_start": "2025-03-15T11:00:00+01:00",
     "title": {
@@ -287,7 +287,7 @@
     "status": "AUTO",
     "work_start": "2025-02-11T14:58:00+01:00",
     "systems": [
-        "ALL"
+        "ERDA"
     ],
     "announce_start": "2025-02-11T14:58:00+01:00",
     "title": {
@@ -1065,7 +1065,7 @@
     "status": "AUTO",
     "work_start": "2024-02-13T19:00:00+01:00",
     "systems": [
-        "ALL"
+        "ERDA"
     ],
     "announce_start": "2024-02-13T09:00:00+01:00",
     "title": {
@@ -1087,7 +1087,7 @@
     "status": "AUTO",
     "work_start": "2024-02-08T09:00:00+01:00",
     "systems": [
-        "ALL"
+        "ERDA"
     ],
     "announce_start": "2024-02-08T09:00:00+01:00",
     "title": {
@@ -1108,7 +1108,7 @@
     "status": "AUTO",
     "work_start": "2024-02-06T16:22:00+01:00",
     "systems": [
-        "ALL"
+        "ERDA"
     ],
     "announce_start": "2024-02-06T16:22:00+01:00",
     "title": {
@@ -1129,7 +1129,7 @@
     "status": "AUTO",
     "work_start": "2024-02-05T09:00:00+01:00",
     "systems": [
-        "ALL"
+        "ERDA"
     ],
     "announce_start": "2024-02-05T09:00:00+01:00",
     "title": {


### PR DESCRIPTION
Fix a number of status event entries incorrectly declared as `ALL` systems where it was in fact only `ERDA` or specific ERDA components. I guess they multiplied from copy/paste so now fixed back in time, too.