### PR TITLE
Add information about SIF update and moving of backend storage

### DIFF
--- a/state/wwwpublic/status-events.json
+++ b/state/wwwpublic/status-events.json
@@ -1,5 +1,26 @@
 [
   {
+      "status": "AUTO",
+      "work_start": "2025-10-03T08:00:00+02:00",
+      "systems": [
+          "SIF"
+      ],
+      "announce_start": "2025-09-17T08:00:00+02:00",
+      "title": {
+          "EN": "Update of SIF and moving backend.",
+          "DK": "Opdatering af SIF og flytning af backend."
+      },
+      "services": [
+          "ALL"
+      ],
+      "work_end": "2025-10-03T23:59:59+02:00",
+      "description": {
+          "EN": "SIF will be updated, and the backend storage will be moved to a new server room. This announcement will be updated on the day with any updates, but expect some downtime for SIF on the day.",
+          "DK": "SIF vil blive opdateret, og backend-lagringen vil blive flyttet til et nyt serverrum. Denne annoncering vil blive opdateret på dagen med opdateringer, men forvent nogen nedetid for SIF på dagen."
+      },
+      "announce_end": "2025-10-04T08:00:00+02:00"
+  },
+  {
     "status": "AUTO",
     "work_start": "2025-09-02T08:00:00+02:00",
     "systems": [

--- a/state/wwwpublic/status-events.json
+++ b/state/wwwpublic/status-events.json
@@ -1,24 +1,24 @@
 [
   {
-      "status": "AUTO",
-      "work_start": "2025-10-03T08:00:00+02:00",
-      "systems": [
-          "SIF"
-      ],
-      "announce_start": "2025-09-17T08:00:00+02:00",
-      "title": {
-          "EN": "Update of SIF and moving backend.",
-          "DK": "Opdatering af SIF og flytning af backend."
-      },
-      "services": [
-          "ALL"
-      ],
-      "work_end": "2025-10-03T23:59:59+02:00",
-      "description": {
-          "EN": "SIF will be updated, and the backend storage will be moved to a new server room. This announcement will be updated on the day with any updates, but expect some downtime for SIF on the day.",
-          "DK": "SIF vil blive opdateret, og backend-lagringen vil blive flyttet til et nyt serverrum. Denne annoncering vil blive opdateret på dagen med opdateringer, men forvent nogen nedetid for SIF på dagen."
-      },
-      "announce_end": "2025-10-04T08:00:00+02:00"
+    "status": "AUTO",
+    "work_start": "2025-10-03T08:00:00+02:00",
+    "systems": [
+        "SIF"
+    ],
+    "announce_start": "2025-09-17T08:00:00+02:00",
+    "title": {
+        "EN": "Update of SIF and moving backend.",
+        "DK": "Opdatering af SIF og flytning af backend."
+    },
+    "services": [
+        "ALL"
+    ],
+    "work_end": "2025-10-03T23:59:59+02:00",
+    "description": {
+        "EN": "SIF will be updated, and the backend storage will be moved to a new server room. This announcement will be updated on the day with any updates, but expect some downtime for SIF on the day.",
+        "DK": "SIF vil blive opdateret, og backend-lagringen vil blive flyttet til et nyt serverrum. Denne annoncering vil blive opdateret på dagen med opdateringer, men forvent nogen nedetid for SIF på dagen."
+    },
+    "announce_end": "2025-10-04T08:00:00+02:00"
   },
   {
     "status": "AUTO",


### PR DESCRIPTION
Adding information about upcoming update to SIF and moving of backend storage with a warning to expect downtime in the period. The work period should potentially be shortened, as it is currently from 08:00 to 23:59.